### PR TITLE
DT-2117 Set locale to formatter for proper ISO string mapping

### DIFF
--- a/MTDates.podspec
+++ b/MTDates.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         	= "MTDates"
-  s.version      	= "1.0.3"
+  s.version      	= "1.0.3.1"
   s.summary      	= "A category on NSDate. 100+ date calculation methods."
   s.homepage     	= "https://github.com/mysterioustrousers/MTDates"
   s.license      	= 'MIT'
   s.author       	= { "Adam Kirk" => "atomkirk@gmail.com" }
-  s.source       	= { :git => "https://github.com/mysterioustrousers/MTDates.git", :tag => "#{s.version}" }
+  s.source       	= { :git => "https://github.com/techery/MTDates.git", :tag => "#{s.version}" }
   s.source_files 	= 'MTDates/*.{h,m}'
   s.ios.deployment_target = "7.0"
   s.osx.deployment_target = "10.8"

--- a/MTDates/NSDate+MTDates.m
+++ b/MTDates/NSDate+MTDates.m
@@ -109,6 +109,9 @@ NSInteger const MTDateConstantHoursInDay        = 24;
     }
 
     NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+    NSString *currentLocaleString = [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
+    NSLocale *formatterLocale = [[NSLocale alloc] initWithLocaleIdentifier:currentLocaleString];
+    [formatter setLocale:formatterLocale];
     [formatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]];
     [formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
 


### PR DESCRIPTION
MTDates has an issue with mapping ISO string to date in some cases.
To fix this I set locale to formatter
